### PR TITLE
Add ComfyUI GPU Monitor

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -32147,6 +32147,15 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
+		{
+			"author": "Hakan Adil",
+			"title": "ComfyUI GPU Monitor",
+			"id": "comfyui-gpu-monitor",
+			"reference": "https://github.com/HakanAdil/ComfyUI-GPU-Monitor",
+			"files": [],
+			"install_type": "git",
+			"description": "Ultra-slim GPU monitor toolbar for ComfyUI (GPU%, VRAM%, °C, W)."
+			}
     ]
 }


### PR DESCRIPTION
Adds a new lightweight GPU monitor extension to the ComfyUI-Manager list.

- Ultra-slim toolbar overlay that shows GPU%, VRAM%, °C, and W
- Draggable mini grip (position persists via localStorage)
- One frontend file + `/gpu` JSON endpoint (NVML; optional Torch stats)
- Repository: https://github.com/HakanAdil/ComfyUI-GPU-Monitor
- License: MIT

Manager entry (JSON):
- id: `comfyui-gpu-monitor`
- install_type: `git`
- branch: `main`
